### PR TITLE
Fixes for spanish movies and shows

### DIFF
--- a/common.py
+++ b/common.py
@@ -294,6 +294,14 @@ class Filtering:
             res = True
         return res
 
+    def remove_characters(self, name):
+        from unicodedata import normalize
+        import types
+
+        uname = unicode(name, 'utf-8', 'ignore')
+        normalize_name = normalize('NFKD',uname)
+        return normalize_name.encode('ascii', 'ignore')
+    
     @staticmethod
     def normalize(name):
         from unicodedata import normalize
@@ -366,8 +374,16 @@ def translator(imdb_id, language, extra=True):
                      "&external_source=imdb_id" % (imdb_id, language)
     if browser1.open(url_themoviedb):
         movie = json.loads(browser1.content)
-        title = movie['movie_results'][0]['title'].encode('utf-8')
-        original_title = movie['movie_results'][0]['original_title'].encode('utf-8')
+        if(len(movie['movie_results']) > 0):
+            title = movie['movie_results'][0]['title'].encode('utf-8')
+            original_title = movie['movie_results'][0]['original_title'].encode('utf-8')
+        elif(len(movie['tv_results']) > 0):
+            title = movie['tv_results'][0]['name'].encode('utf-8')
+            original_title = movie['tv_results'][0]['original_name'].encode('utf-8')
+        else:
+            title = "";
+            original_title = ""
+
         if title == original_title and extra:
             title += ' ' + keywords[language]
     else:

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 __author__ = 'mancuniancol'
 
 import common
+import copy
 from bs4 import BeautifulSoup
 from quasar import provider
 
@@ -90,6 +91,17 @@ def search_movie(info):
 
 
 def search_episode(info):
+    trans_title = filters.remove_characters(common.translator(info['imdb_id'],"es"))
+    trans_info = copy.deepcopy(info)
+    trans_info['title'] = trans_title
+
+    results1 = search_episode_routine(info)
+    results2 = search_episode_routine(trans_info)
+    results = results1 + results2
+    
+    return results
+
+def search_episode_routine(info):
     settings.value["language"] = settings.value.get("language", "es")
     if info['absolute_number'] == 0:
         info["type"] = "show"
@@ -104,7 +116,6 @@ def search_episode(info):
         info["type"] = "anime"
         info["query"] = info['title'].encode('utf-8') + ' %02d' % info['absolute_number']  # define query anime
     return search_general(info)
-
 
 def search_season(info):
     provider.log.info(info)

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
     <category label="32050">
-        <setting label="32093" type="text" id="url_address" default="http://1337x.to"/>
+        <setting label="32093" type="text" id="url_address" default="http://www.elitetorrent.net"/>
         <!--<setting label="32199" type="lsep"/>-->
         <!--<setting label="32151" type="labelenum" id="language" values="en|de|es|fr|it|pt" default="es"/>-->
         <setting label="32200" type="lsep"/>


### PR DESCRIPTION
The address of the web page has been corrected in the resources.

The search for TV Shows is a bit tricky here, as it uses the spanish name in some and the english one in others. To avoid problems two searches are done, one with each language, and their results united and returned. This seems to work perfectly fine in the shows I have tested (In PC and Raspberry 2).

Addiditonally in common.py I have modified the transation function to use it with TV Shows and I have added a function to remove accent marks that is used in a change I made in another provider (which I am going to after this one).